### PR TITLE
Add dub.json file.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,25 @@
+{
+    "name": "decimal",
+    "authors": [
+        "rumbu13"
+    ],
+    "description": "IEEE-754-2008 compliant decimal data type.",
+    "copyright": "Copyright © 2017 rumbu13",
+    "license": "proprietary",
+    "sourcePaths": [ "src/" ],
+    "configurations": [
+        {
+            "name": "library",
+            "excludedSourceFiles": [ "src/benchmark.d", "src/test.d" ]
+        },
+        {
+            "name": "unittest",
+            "excludedSourceFiles": [ "src/benchmark.d", "src/test.d" ]
+        },
+        {
+            "name": "benchmark",
+            "targetType": "executable",
+            "excludedSourceFiles": [ "src/test.d" ]
+        }
+    ]
+}


### PR DESCRIPTION
You'll want to edit this to change author/copyright/license information to whatever you'd like before accepting.

This allows dub to build decimal; from here you could add it to code.dlang.org for greater visibility.

I have added the benchmark as a build option, but benchmark.d is just an empty main(). Is something supposed to be there?